### PR TITLE
Fix concurrency issue during launch. NEOFORGE

### DIFF
--- a/src/main/resources/META-INF/neoforge.mods.toml
+++ b/src/main/resources/META-INF/neoforge.mods.toml
@@ -39,7 +39,7 @@ side = "BOTH"
 modId = "create"
 type = "required"
 versionRange = "[6.0,)"
-ordering = "NONE"
+ordering = "AFTER"
 side = "BOTH"
 
 [[dependencies.northstar]]


### PR DESCRIPTION
Fixes #122 for Neoforge.

By ensuring a load order, Northstar is loaded after Create, ensuring that all of its classes are already loaded so that Northstar cannot interfere by accidentally being the first to load Create classes.